### PR TITLE
Completed implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# jordan-saved-filter-ui
- 
+# Saved filter UI
+
+Implementation of a flexible "filter builder" ui. Component was built to be intuitive, flexible, enable keyboard navigation, and take up as little verticial space as possible.
+
+### Running locally:
+
+1. Clone repo
+2. `npm install`
+3. `npm run start`
+
+### Example usage:
+
+```
+import { FilterBuilderView } from "./FilterBuilderView.tsx";
+import { ColumnType, ViewResult } from "./types.ts";
+
+const App = () => {
+  const columnData = [
+    { key: "name", type: ColumnType.STRING },
+    { key: "accountsOwned", type: ColumnType.NUMBER },
+    { key: "dataAdded", type: ColumnType.DATE },
+  ];
+
+  return (
+      <FilterBuilderView
+        columnData={columnData}
+        onChange={(result: ViewResult) =>
+          setTextValue(JSON.stringify(result, null, 2))
+        }
+      />
+  );
+};
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
+import "./styles.css";
+import { FilterBuilderView } from "./FilterBuilderView/FilterBuilderView.tsx";
+import { ColumnType, ViewResult } from "./FilterBuilderView/types.ts";
 
 export const App = () => {
-  return <h1>Hello</h1>;
+  const [textValue, setTextValue] = useState("");
+  const columnData = [
+    { key: "name", type: ColumnType.STRING },
+    { key: "accountsOwned", type: ColumnType.NUMBER },
+    { key: "dataAdded", type: ColumnType.DATE },
+  ];
+
+  return (
+    <>
+      <FilterBuilderView
+        columnData={columnData}
+        onChange={(result: ViewResult) =>
+          setTextValue(JSON.stringify(result, null, 2))
+        }
+      />
+      <pre>{textValue}</pre>
+    </>
+  );
 };

--- a/src/FilterBuilderView/FilterBuilderView.tsx
+++ b/src/FilterBuilderView/FilterBuilderView.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useReducer } from "react";
+import { FilterPill } from "./components/FilterPill/FilterPill.tsx";
+import {
+  filterViewReducer,
+  initFilterView,
+  isFilterValid,
+} from "../FilterBuilderView/state/filterView.ts";
+import { ViewResult, Column, Filter } from "./types.ts";
+
+export interface FilterBuilderViewProps {
+  columnData: Column[];
+  onChange: (result: ViewResult) => void;
+}
+
+const initialView: ViewResult = {
+  filters: [],
+};
+
+const parseFilterView = (data: ViewResult) => {
+  return {
+    ...data,
+    filters: data.filters.filter(isFilterValid),
+  };
+};
+
+export const FilterBuilderView = ({
+  columnData,
+  onChange,
+}: FilterBuilderViewProps) => {
+  const [filterView, dispatch] = useReducer(
+    filterViewReducer,
+    initialView,
+    initFilterView
+  );
+
+  useEffect(() => {
+    // filter out invalid filters before triggering onChange
+    onChange(parseFilterView(filterView));
+  }, [filterView]);
+
+  const updateFilter = (filter: Filter) =>
+    dispatch({ type: "filter:update", data: filter });
+
+  const deleteFilter = (filter: Filter) =>
+    dispatch({ type: "filter:delete", data: filter });
+
+  return (
+    <div className="filter-wrapper">
+      <label>Filter:</label>
+      <div className="filter-container">
+        {filterView.filters.map((filter) => (
+          <FilterPill
+            key={filter.id}
+            columnData={columnData}
+            initialData={filter}
+            onChange={updateFilter}
+            onDelete={deleteFilter}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/FilterBuilderView/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/FilterBuilderView/components/AutocompleteInput/AutocompleteInput.tsx
@@ -1,0 +1,137 @@
+import React, { useRef, useState, useEffect, useImperativeHandle } from "react";
+
+// generic type on Option.value lets us have type safety on the `onSelect` function param
+interface Option<T> {
+  key: string;
+  label: string;
+  value: T;
+}
+
+export interface AutocompleteInputProps<T> {
+  options: Option<T>[];
+  onSelect: (value: T) => void;
+  defaultValue?: T;
+  inputRef?: React.RefObject<HTMLInputElement>;
+}
+
+export const AutocompleteInput = <T extends unknown>({
+  options,
+  onSelect,
+  defaultValue,
+  inputRef,
+}: AutocompleteInputProps<T>) => {
+  const containerRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const innerInputRef: React.RefObject<HTMLInputElement> = useRef(null);
+  const [active, setActive] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<Option<T> | undefined>(
+    options.find((option) => option.value === defaultValue)
+  );
+  const [availableOptions, setAvailableOptions] = useState<Option<T>[]>([]);
+  const [searchInput, setSearchInput] = useState(selectedOption?.label || "");
+
+  const setInputValue = (value: string) => {
+    // when user clicks a dropdown option set search text to match
+    setSearchInput(value);
+    if (innerInputRef.current) innerInputRef.current.value = value;
+  };
+
+  const onChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    setSearchInput(event.target.value);
+  };
+
+  useEffect(() => {
+    // if user is typing and has not just selected an option then show options as active
+    if (searchInput.length > 0 && selectedOption?.label !== searchInput) {
+      setActive(true);
+    }
+    // if search text is empty then show all options
+    if (searchInput.length === 0) {
+      setAvailableOptions([...options]);
+    } else {
+      // otherwise filter by search text
+      setAvailableOptions(
+        options.filter((option) =>
+          option.label.toLowerCase().includes(searchInput.toLowerCase())
+        )
+      );
+    }
+  }, [searchInput]);
+
+  useEffect(() => {
+    // If user clicks or focuses away from the autocomplete input / options we want to hide the options and reset the text
+    const func = (event) => {
+      if (!containerRef.current?.contains(event.relatedTarget)) {
+        setActive(false);
+        setInputValue(selectedOption ? selectedOption.label : "");
+      }
+    };
+    containerRef.current?.addEventListener("focusout", func);
+    return () => {
+      containerRef.current?.removeEventListener("focusout", func);
+    };
+  }, [containerRef, selectedOption]);
+
+  // ImperativeHandle lets parent component set focus on input element, while allowing this component to also control it when needed.
+  useImperativeHandle(
+    inputRef,
+    () => {
+      return {
+        focus() {
+          innerInputRef.current?.focus();
+        },
+      } as HTMLInputElement;
+    },
+    []
+  );
+
+  // curried function so we can easily call outside of click handler
+  const onClick = (option) => () => {
+    innerInputRef.current?.focus();
+    setSelectedOption(option);
+    onSelect(option.value);
+    setActive(false);
+    setInputValue(option.label);
+  };
+
+  const onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    // gives autocomplete behaviour, if user is typing an hits ENTER key then we want to select first entry in the list
+    if (event.key === "Enter" && availableOptions.length > 0) {
+      onClick(availableOptions[0])();
+    }
+  };
+
+  const onFocus = () => {
+    // when user focuses on the input we want to pre select all text and show autocomplete options,
+    // this makes for quick keyboard navigation and better experience
+    if (searchInput.length > 0) {
+      setActive(true);
+      innerInputRef.current?.select();
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="autocomplete">
+      <input
+        type="text"
+        ref={innerInputRef}
+        className="autocomplete-input"
+        onChange={onChange}
+        defaultValue={selectedOption?.label}
+        onFocus={onFocus}
+        onKeyDown={onKeyPress}
+      />
+      {active && (
+        <ul className="options-container">
+          {/* Limit options in drop down to 15 entries */}
+          {availableOptions.slice(0, 15).map((option) => (
+            <li key={option.key}>
+              <button className="option" tabIndex={0} onClick={onClick(option)}>
+                {option.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/FilterBuilderView/components/FilterPill/FilterPill.tsx
+++ b/src/FilterBuilderView/components/FilterPill/FilterPill.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useRef, useEffect } from "react";
+import { AutocompleteInput } from "../AutocompleteInput/AutocompleteInput.tsx";
+import { TypedInput } from "../TypedInput/TypedInput.tsx";
+import { isFilterValid } from "../../state/filterView.ts";
+import { Filter, FilterOperator, Column } from "../../types.ts";
+
+export interface FilterPillProps {
+  columnData: Column[];
+  onChange: (result: Filter) => void;
+  onDelete: (result: Filter) => void;
+  initialData: Filter;
+}
+
+const FilterOperatorLabels: Record<FilterOperator, string> = {
+  [FilterOperator.EQUALS]: "= (equals)",
+  [FilterOperator.NOT_EQUALS]: "!= (not equals)",
+  [FilterOperator.GREATER_THAN]: "> (greater than)",
+  [FilterOperator.LESS_THAN]: "< (less than)",
+};
+
+const isEmptyFilter = (filter: Filter) => {
+  return filter.column === undefined;
+};
+
+export const FilterPill = ({
+  columnData,
+  initialData,
+  onChange,
+  onDelete,
+}: FilterPillProps) => {
+  const [filterState, setFilterState] = useState(initialData);
+  const operatorRef: React.RefObject<HTMLInputElement> = useRef(null);
+  const valueRef: React.RefObject<HTMLInputElement> = useRef(null);
+
+  useEffect(() => {
+    // column was just set so move user focus to operator input
+    // needs to be in useEffect since we hide the operator ref until column is set
+    operatorRef.current?.focus();
+  }, [filterState?.column]);
+
+  useEffect(() => {
+    if (isFilterValid(filterState)) {
+      // only trigger onChange handler if filter is complete
+      onChange(filterState);
+    }
+  }, [filterState]);
+
+  const setColumn = (column: Column) => {
+    setFilterState((current) => {
+      if (isEmptyFilter(current)) {
+        // if filter is empty then set defaults for other values
+        return {
+          ...current,
+          column: column,
+          operator: FilterOperator.EQUALS,
+          value: undefined,
+        };
+      } else {
+        return {
+          ...current,
+          column: column,
+        };
+      }
+    });
+  };
+
+  const setOperator = (operator: FilterOperator) => {
+    setFilterState((current) => {
+      return {
+        ...current,
+        operator: operator,
+      };
+    });
+    valueRef.current?.focus();
+  };
+
+  const setValue = (value: string | Date | Number) => {
+    setFilterState((current) => {
+      return {
+        ...current,
+        value: value,
+      };
+    });
+  };
+
+  const columnOptions = columnData.map((column) => ({
+    key: column.key,
+    label: column.key,
+    value: column,
+  }));
+
+  const operatorOptions = Object.keys(FilterOperator).map((value) => ({
+    key: value,
+    label: FilterOperatorLabels[value],
+    value: value as FilterOperator,
+  }));
+
+  const filterClass = () => {
+    if (filterState?.column === undefined) {
+      return "filter";
+    }
+    if (!isFilterValid(filterState)) {
+      return "filter-active filter-invalid";
+    }
+    return "filter-active";
+  };
+
+  return (
+    <div className={filterClass()}>
+      {filterState?.column !== undefined && (
+        <button className="filter-close" onClick={() => onDelete(filterState)}>
+          X
+        </button>
+      )}
+      <AutocompleteInput
+        options={columnOptions}
+        defaultValue={filterState?.column}
+        onSelect={setColumn}
+      />
+      {filterState?.column !== undefined && (
+        <AutocompleteInput
+          options={operatorOptions}
+          inputRef={operatorRef}
+          defaultValue={filterState.operator}
+          onSelect={setOperator}
+        />
+      )}
+      {filterState?.column !== undefined && (
+        <TypedInput
+          type={filterState.column.type}
+          defaultValue={filterState.value}
+          inputRef={valueRef}
+          onChange={setValue}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/FilterBuilderView/components/TypedInput/TypedInput.tsx
+++ b/src/FilterBuilderView/components/TypedInput/TypedInput.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from "react";
+import { useDebouncedValue } from "../../hooks/useDebouncedValue.ts";
+import { ColumnType } from "../../types.ts";
+
+// the generics allow us to narrow the props on the sub input fields
+type OnChangeProp<T> = (value: T) => void;
+
+export interface TypedInputProps {
+  type: ColumnType;
+  onChange: OnChangeProp<Date | Number | string>;
+  defaultValue?: Date | Number | string;
+  inputRef?: React.RefObject<HTMLInputElement>;
+}
+
+export const TypedInput = ({
+  type,
+  onChange,
+  defaultValue,
+  inputRef,
+}: TypedInputProps) => {
+  switch (type) {
+    case ColumnType.NUMBER: {
+      return (
+        <NumberInput
+          inputRef={inputRef}
+          onChange={onChange as OnChangeProp<Number>}
+          defaultValue={defaultValue as Number}
+        />
+      );
+    }
+    case ColumnType.DATE: {
+      return (
+        <DateInput
+          inputRef={inputRef}
+          onChange={onChange as OnChangeProp<Date>}
+          defaultValue={defaultValue as Date}
+        />
+      );
+    }
+    case ColumnType.STRING: {
+      return (
+        <StringInput
+          inputRef={inputRef}
+          onChange={onChange as OnChangeProp<string>}
+          defaultValue={defaultValue as string}
+        />
+      );
+    }
+  }
+};
+
+interface StringInputProps {
+  defaultValue?: string;
+  onChange: (value: string) => void;
+  inputRef?: React.RefObject<HTMLInputElement>;
+}
+
+const StringInput = ({
+  defaultValue,
+  onChange,
+  inputRef,
+}: StringInputProps) => {
+  const [value, setValue] = useState(defaultValue);
+  const debouncedValue = useDebouncedValue(value);
+
+  useEffect(() => {
+    debouncedValue && onChange(debouncedValue);
+  }, [debouncedValue]);
+
+  const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (event) =>
+    setValue(event.target.value);
+
+  return (
+    <input
+      ref={inputRef}
+      onChange={onChangeHandler}
+      defaultValue={defaultValue || ""}
+    />
+  );
+};
+
+interface DateInputProps {
+  defaultValue?: Date;
+  onChange: (value: Date) => void;
+  inputRef?: React.RefObject<HTMLInputElement>;
+}
+
+const isDate = (value: unknown): value is Date => {
+  return value !== undefined && value instanceof Date;
+};
+
+const DateInput = ({ defaultValue, onChange, inputRef }: DateInputProps) => {
+  const [value, setValue] = useState(defaultValue);
+  const debouncedValue = useDebouncedValue(value);
+
+  useEffect(() => {
+    isDate(debouncedValue) && onChange(debouncedValue);
+  }, [debouncedValue]);
+
+  const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (event) =>
+    setValue(new Date(event.target.value));
+
+  return (
+    <input
+      type="date"
+      ref={inputRef}
+      onChange={onChangeHandler}
+      defaultValue={isDate(defaultValue) ? defaultValue.toISOString() : ""}
+    />
+  );
+};
+
+interface NumberInputProps {
+  defaultValue?: Number;
+  onChange: (value: Number) => void;
+  inputRef?: React.RefObject<HTMLInputElement>;
+}
+
+const NumberInput = ({
+  defaultValue,
+  onChange,
+  inputRef,
+}: NumberInputProps) => {
+  const [value, setValue] = useState(defaultValue || 0);
+  const debouncedValue = useDebouncedValue(value);
+
+  useEffect(() => {
+    onChange(debouncedValue);
+  }, [debouncedValue]);
+
+  const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (event) =>
+    setValue(Number(event.target.value));
+
+  return (
+    <input
+      type="number"
+      ref={inputRef}
+      value={value?.toString() || ""} // we use a controlled input specifically here in order to inforce the number formatting and validation
+      onChange={onChangeHandler}
+    />
+  );
+};

--- a/src/FilterBuilderView/hooks/useDebouncedValue.ts
+++ b/src/FilterBuilderView/hooks/useDebouncedValue.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from "react";
+
+export const useDebouncedValue = <T extends unknown>(
+  value: T,
+  delay: number = 500
+) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+};

--- a/src/FilterBuilderView/state/filterView.ts
+++ b/src/FilterBuilderView/state/filterView.ts
@@ -1,0 +1,97 @@
+import { Filter, ViewResult } from "../types.ts";
+
+export type FilterViewAction =
+  | { type: "filter:update"; data: Filter }
+  | { type: "filter:delete"; data: Filter };
+
+export const filterViewReducer = (
+  state: ViewResult,
+  action: FilterViewAction
+): ViewResult => {
+  switch (action.type) {
+    case "filter:update": {
+      return {
+        ...state,
+        filters: addOrUpdateFilter(state.filters, action.data),
+      };
+    }
+    case "filter:delete": {
+      return {
+        ...state,
+        filters: deleteFilter(state.filters, action.data),
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export const initFilterView = (initialData: ViewResult): ViewResult => {
+  // We always want 1 and only 1 "empty" filter so the user has a starting point
+  if (hasEmptyFilter(initialData.filters)) {
+    return initialData;
+  }
+
+  return {
+    filters: [...initialData.filters, buildEmptyFilter()],
+  };
+};
+
+export const isFilterValid = (filter?: Filter): filter is Filter => {
+  return (
+    filter !== undefined &&
+    filter.column !== undefined &&
+    filter.operator !== undefined &&
+    filter.value !== undefined
+  );
+};
+
+const buildEmptyFilter = (): Filter => ({
+  // use UUID so we can edit / delete by reference
+  id: crypto.randomUUID(),
+  column: undefined,
+  operator: undefined,
+  value: undefined,
+});
+
+const hasEmptyFilter = (filters: Filter[]) => {
+  return filters.findIndex((filter) => filter.column === undefined) !== -1;
+};
+
+const addOrUpdateFilter = (filters: Filter[], data: Filter) => {
+  const newFilters = [...filters];
+  const existingFilter = newFilters.findIndex(
+    (filter) => filter.id === data.id
+  );
+  if (existingFilter === -1) {
+    newFilters.push(data);
+  } else {
+    newFilters[existingFilter] = { ...data };
+  }
+
+  if (!hasEmptyFilter(newFilters)) {
+    // if filters no longer have an empty entry add one at the end so users can add another
+    newFilters.push(buildEmptyFilter());
+  }
+
+  return newFilters;
+};
+
+const deleteFilter = (filters: Filter[], data: Filter) => {
+  const newFilters = [...filters];
+  const existingFilter = newFilters.findIndex(
+    (filter) => filter.id === data.id
+  );
+  if (existingFilter === -1) {
+    return newFilters;
+  }
+
+  newFilters.splice(existingFilter, 1);
+  if (!hasEmptyFilter(newFilters)) {
+    // if filters no longer have an empty entry add one at the end so users can add another
+    newFilters.push(buildEmptyFilter());
+  }
+
+  return newFilters;
+};

--- a/src/FilterBuilderView/types.ts
+++ b/src/FilterBuilderView/types.ts
@@ -1,0 +1,33 @@
+export enum ColumnType {
+  STRING = "STRING",
+  NUMBER = "NUMBER",
+  DATE = "DATE",
+}
+
+export interface Column {
+  key: string;
+  type: ColumnType;
+}
+
+interface FilledFilter {
+  id: string;
+  column: Column;
+  operator: FilterOperator;
+  value: Date | Number | string;
+}
+
+// Partial and Pick combination here results in a Filter object where only the "id" field is set
+type EmptyFilter = Partial<FilledFilter> & Pick<FilledFilter, "id">;
+
+export type Filter = FilledFilter | EmptyFilter;
+
+export interface ViewResult {
+  filters: Filter[];
+}
+
+export enum FilterOperator {
+  EQUALS = "EQUALS",
+  NOT_EQUALS = "NOT_EQUALS",
+  GREATER_THAN = "GREATER_THAN",
+  LESS_THAN = "LESS_THAN",
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,96 @@
+.filter-wrapper {
+  display: flex;
+}
+
+.filter-wrapper > label {
+  background-color: #d9d9d9;
+  padding: 10px;
+  border-radius: 5px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.filter-container {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  border: 1px solid;
+  border-radius: 5px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding: 5px;
+}
+
+.filter-container > div {
+  display: flex;
+  margin: 2px 0px;
+  margin-left: 5px;
+}
+
+.filter-close {
+  border: none;
+  border-radius: 5px;
+  margin: 2px 0px;
+  margin-right: 10px;
+  color: #939393;
+}
+
+.filter input {
+  border: none;
+  border-left: 1px solid black;
+  width: 100%;
+}
+
+.filter,
+.filter .autocomplete {
+  flex: 1;
+}
+
+.filter {
+  padding: 5px 0px;
+}
+
+.filter-active {
+  background-color: #b7f2f9;
+  border-radius: 5px;
+  padding: 5px 10px;
+}
+
+.filter-invalid {
+  background-color: #ee9292;
+}
+
+.filter-active input {
+  width: 120px;
+}
+.filter-active .autocomplete:first-of-type > input {
+  width: 150px;
+}
+
+.autocomplete {
+  position: relative;
+}
+
+.options-container {
+  position: absolute;
+  padding: 0px;
+  margin: 0;
+  list-style: none;
+  width: 100%;
+  max-width: 150px;
+  z-index: 9;
+  background-color: white;
+}
+
+.options-container .option {
+  width: 100%;
+  border: none;
+  padding: 5px 10px;
+  text-align: left;
+  display: inline-block;
+  margin: 2px 0px;
+}
+
+.options-container:not(:focus-within) > li:first-child button {
+  outline: 2px solid rgb(8, 106, 211);
+}


### PR DESCRIPTION
## Changes
Adds FilterBuilderView, styling, and example usage.

## Testing / Demo:

https://github.com/jordan-goo/jordan-saved-filter-ui/assets/10941066/c06fcee3-ea7c-496e-acc3-62e93c64c0b5

## Decisions / Talking points

- I focused on behavior and UX for the most part, I really wanted to get the intuitive controls and keyboard navigation working well.
- Didn't worry too much about styling, usually an existing component library is used anyways so I used a single css file instead of pulling in something more complex like Tailwind or a css-in-js library.
- I decided to keep the whole thing dependency free, while there are probably tons of "Autocomplete" components or "Input" components available on npm I wanted to make sure what I had worked well together and I didn't want to over complicate things.
- Chose to use native html controls wherever possible and not use state-controlled inputs (except in the number input), I think this keeps internal state a lot cleaner and takes advantage of a lot of browser features that already exist.
- Most of the internal state is pretty simple, one exception is the use of `useReducer` in `FilterBuilderView`. I think I could have used a normal `useState` hook, but knowing I would want to expand it in the future to add "sort" and "group by", I think the reducer makes it a lot easier to extend.
